### PR TITLE
fix(article): only return repliesFetchedAt when the article has replies

### DIFF
--- a/api/src/controllers/article.js
+++ b/api/src/controllers/article.js
@@ -168,6 +168,12 @@ exports.get = async (req, res) => {
 
 	article.unread = false;
 
+	// repliesFetchedAt is only meaningful alongside fetched replies; drop it
+	// unless the article actually has replies data.
+	if (!article.replies || article.replies.length === 0) {
+		delete article.repliesFetchedAt;
+	}
+
 	res.json(article);
 };
 


### PR DESCRIPTION
## What
`repliesFetchedAt` is **kept** as the internal v2ex fetch cache gate (the 30-min TTL that prevents re-hitting the API, including for zero-reply topics). This change only trims the **response**: the field is returned to clients only when the article actually has reply data.

So:
- v2ex article **with** fetched replies → `replies` + `repliesFetchedAt` (timestamp) returned, as before.
- v2ex topic with **no** replies, or **non-v2ex** articles → `repliesFetchedAt` is omitted (no stray `null`/timestamp).

## Notes
- The column and the cache-gate logic in `syncV2EXReplies` are unchanged; `getArticleById` still selects it internally.
- Coupled to `article.replies` presence rather than the timestamp value, so the field never appears without data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)