### PR TITLE
fix(v2ex): don't discard fetched replies when the Redis cache write fails

### DIFF
--- a/api/src/utils/v2ex.js
+++ b/api/src/utils/v2ex.js
@@ -138,7 +138,13 @@ export const syncV2EXReplies = async (article) => {
 	try {
 		const items = await fetchAllReplies(topicId);
 		const replies = items.map(mapReply);
-		await cache.set(key, replies, (config.v2ex.ttl || 30) * 60);
+		// Cache write is best-effort; a Redis hiccup must not discard the
+		// replies we just fetched.
+		cache
+			.set(key, replies, (config.v2ex.ttl || 30) * 60)
+			.catch((err) =>
+				logger.warn(`Failed to cache v2ex replies for topic ${topicId}: ${err.message}`),
+			);
 		return replies;
 	} catch (err) {
 		logger.warn(`Failed to fetch v2ex replies for topic ${topicId}: ${err.message}`);


### PR DESCRIPTION
## Bug
`cache.set` was `await`ed inside the same `try` that returns the replies. If Redis rejects the write (connection hiccup, etc.), it fell through to the `catch` and returned `[]` — discarding replies that were already fetched successfully from the v2ex API.

## Fix
Make the cache write best-effort: fire-and-forget with its own `.catch` warn handler, and return the fetched replies regardless of whether caching succeeded. The fetch failure path is unchanged (still caught by the outer try/catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)