### PR TITLE
fix(ui): isolate v2ex reply styles from .article-content collisions

### DIFF
--- a/app/src/components/Feeds/ArticleReplies.js
+++ b/app/src/components/Feeds/ArticleReplies.js
@@ -48,7 +48,7 @@ const ArticleReplies = ({ article = {} }) => {
 								)}
 							</div>
 							<div className="body">
-								<div className="meta">
+								<div className="reply-meta">
 									{author.url ? (
 										<a
 											href={author.url}
@@ -71,7 +71,7 @@ const ArticleReplies = ({ article = {} }) => {
 									)}
 								</div>
 								<div
-									className="content"
+									className="reply-content"
 									dangerouslySetInnerHTML={{
 										__html: sanitizeHTML(reply.contentRendered || reply.content),
 									}}

--- a/app/src/styles/components/_article-content.scss
+++ b/app/src/styles/components/_article-content.scss
@@ -297,7 +297,7 @@
       min-width: 0;
     }
 
-    .meta {
+    .reply-meta {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -305,7 +305,6 @@
       font-size: 0.8125rem;
       color: var(--text-light);
       margin-bottom: rem(4px);
-      border-bottom: 0;
 
       .username {
         font-weight: 600;
@@ -330,7 +329,7 @@
       }
     }
 
-    .content {
+    .reply-content {
       font-size: 0.9375rem;
       line-height: 1.6;
       color: var(--text-dark);


### PR DESCRIPTION
## Problem
On mobile (≤480px) the reply meta row (username / floor / time / thanks) was centered. Root cause: reply rows reused the `.meta` and `.content` class names, so global `.article-content .meta`/`.content` rules leaked into them via the descendant cascade:
- `@media (max-width: 480px) .article-content .meta { flex-direction: column }` → centered the reply meta,
- `.article-content .meta { border-bottom }` → drew a stray divider.

Each had been worked around with a counter-override inside the reply block (`flex-direction: row`, `border-bottom: 0`) — whack-a-mole.

## Fix
Rename the reply elements to `.reply-meta` / `.reply-content` so they don't inherit the article's `.meta`/`.content` rules at all, and remove the now-unneeded overrides. The reply block is self-contained instead of fighting cascade leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)